### PR TITLE
feat: add FULL_PRODUCT_NAME column combining product and brand

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "smart-receipt-assistant"
-version = "0.1.0"
+version = "0.1.1"
 description = "A Streamlit app to upload and analyze supermarket invoices with a dashboard for spending insights."
 authors = ["Arthur Yuan"]
 license = "MIT"

--- a/src/database.py
+++ b/src/database.py
@@ -116,6 +116,7 @@ def load_invoice_data(engine) -> pd.DataFrame:
         raise RuntimeError("Failed to load or parse data from the database") from e
 
 if __name__ == '__main__':
+    # Create database
     create_postgres_database(DB_NAME, DB_HOST, DB_PORT, DB_USER, DB_PASSWORD)
     run_sql_commands(DB_NAME, DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, sql_commands)
 

--- a/src/prompt_template.py
+++ b/src/prompt_template.py
@@ -12,6 +12,7 @@ invoice_prompt = """
         - VL UN R$ (valor unitário)
         - VL ITEM R$ (valor total do item)
         - PRODUTO (nome genérico, como Leite, Detergente, Frango, etc.)
+        - PRODUTO MARCA: nome genérico mais a marca, como Leite Italac, Detergente Ypê, Frango Sadia. Quando for produto natural, como alho, cebola, uva, manter apenas o nome.
         - VOLUME (ex: "1L", "500ML", "1KG"; se não houver, usar NULL)
         - CATEGORIA (categoria do produto)
 
@@ -26,15 +27,15 @@ invoice_prompt = """
 
         **Saída esperada**
         **Exemplo 1**
-        INSERT INTO invoices (invoice_id, supermarket_name, datetime, description, quantity, unit, unitary_value, total_value, product, volume, category) VALUES
-        (35250447508411271427651040001883521912124444,ASSAI ATACADISTA,01/01/2023,'LTE ITALAC ZERO 1L',3.00, 'Un', 5.89, 17.60, 'Leite', '1L', 'Laticínios'),
-        (35250447508411271427651040001883521912124444,ASSAI ATACADISTA,01/01/2023,'P QJ SIBERI 1kg TRAD',1.00, 'PC', 14.10, 14.10, 'Pão de Queijo', '1KG', 'Padaria e Confeitaria'),
-        (35250447508411271427651040001883521912124444,ASSAI ATACADISTA,01/01/2023,'SASSAMI SADIA 1kg',4.00, 'PC', 20.90, 83.60, 'Frango' , '1KG', 'Carnes e Aves');
+        INSERT INTO invoices (invoice_id, supermarket_name, datetime, description, quantity, unit, unitary_value, total_value, product, full_product_name, volume, category) VALUES
+        (35250447508411271427651040001883521912124444,ASSAI ATACADISTA,01/01/2023,'LTE ITALAC ZERO 1L',3.00, 'Un', 5.89, 17.60, 'Leite', 'Leite Italac,'1L', 'Laticínios'),
+        (35250447508411271427651040001883521912124444,ASSAI ATACADISTA,01/01/2023,'P QJ SIBERI 1kg TRAD',1.00, 'PC', 14.10, 14.10, 'Pão de Queijo', 'Pão de Queijo Siberi','1KG', 'Padaria e Confeitaria'),
+        (35250447508411271427651040001883521912124444,ASSAI ATACADISTA,01/01/2023,'SASSAMI SADIA 1kg',4.00, 'PC', 20.90, 83.60, 'Frango', 'Frango Sadia','1KG', 'Carnes e Aves');
         
         **Exemplo 2**
-        INSERT INTO invoices (invoice_id, supermarket_name, datetime, description, quantity, unit, unitary_value, total_value, product, volume, category) VALUES
-        (35250447508411271427651040001874681561004444,CIA BRASILEIRA DE DISTRIBUICAO,01/03/2025,' CERV BLUE MOON 350ML',1.00, 'Un', 8.99, 8.99, 'Cerveja', '350ML', 'Bebidas'),
-        (35250447508411271427651040001874681561004444,CIA BRASILEIRA DE DISTRIBUICAO,01/03/2025,'ORFEU TM INT 250G ',1.00, 'Un', 38.99, 38.99, 'Café', '250G', 'Bebidas');
+        INSERT INTO invoices (invoice_id, supermarket_name, datetime, description, quantity, unit, unitary_value, total_value, product, full_product_name, volume, category) VALUES
+        (35250447508411271427651040001874681561004444,CIA BRASILEIRA DE DISTRIBUICAO,01/03/2025,'CERV BLUE MOON 350ML',1.00, 'Un', 8.99, 8.99, 'Cerveja', 'Cerveja Blue Moon','350ML', 'Bebidas'),
+        (35250447508411271427651040001874681561004444,CIA BRASILEIRA DE DISTRIBUICAO,01/03/2025,'ORFEU TM INT 250G ',1.00, 'Un', 38.99, 38.99, 'Cafe', 'Cafe Orfeu','250G', 'Bebidas');
 
     Cupom fiscal:
     {receipt}

--- a/src/sql_commands.py
+++ b/src/sql_commands.py
@@ -10,6 +10,7 @@ sql_commands = [
         unitary_value DECIMAL(10,2) NOT NULL,
         total_value DECIMAL(10,2) NOT NULL,
         product TEXT NOT NULL,
+        full_product_name TEXT NOT NULL,
         volume VARCHAR(10),
         category TEXT NOT NULL
     );


### PR DESCRIPTION
## 🚀 Feature: Add `full_product_name` column to invoice schema

### Summary
This merge request introduces a new column `full_product_name` to the invoice data model, which combines the generic product name with its brand (e.g., **"Leite Italac"**, **"Frango Sadia"**). This enhances product clarity and enables more detailed filtering and analysis in the dashboard.

---

### ✅ Changes Made
- Added `full_product_name` to the database schema (`sql_commands.py`)
- Updated prompt templates in `prompt_template.py` to reflect the new column
- Bumped project version to `0.1.1` in `pyproject.toml`
- Minor structural improvement in `database.py`

---

### 📌 Motivation
Many items share the same generic label (e.g., "Leite", "Café"), but differ by brand. Including the brand in a separate, structured column allows for:
- Better grouping and filtering in analytics
- Improved accuracy in identifying recurring purchases by brand
- Cleaner display in dashboards

